### PR TITLE
Fixes #7 Executables can follow symbolic links

### DIFF
--- a/bin/find-json-schema
+++ b/bin/find-json-schema
@@ -10,7 +10,7 @@ home = os.path.expanduser('~')
 gsonJar = os.path.abspath(os.path.join(home, ".m2", "repository", "com",
 	"google", "code", "gson", "gson", gsonVersion, 
 	"gson-%s.jar" % gsonVersion))
-ourJar = os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
+ourJar = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..",
        "target", "hive-json-%s.jar" % ourVersion))
 
 if not os.path.exists(gsonJar):

--- a/bin/shred-json
+++ b/bin/shred-json
@@ -10,7 +10,7 @@ home = os.path.expanduser('~')
 gsonJar = os.path.abspath(os.path.join(home, ".m2", "repository", "com",
 	"google", "code", "gson", "gson", gsonVersion, 
 	"gson-%s.jar" % gsonVersion))
-ourJar = os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
+ourJar = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..",
        "target", "hive-json-%s.jar" % ourVersion))
 
 if not os.path.exists(gsonJar):


### PR DESCRIPTION
Use os.path.realpath to resolve symbolic links